### PR TITLE
W-23461549 fix(ci): align DataWeave versions to fix native-cli test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run Build (Latest)
         run: |
-          ./gradlew --stacktrace --no-problems-report -PskipNodeTests=true -PweaveVersion=2.11.0-SNAPSHOT -PweaveTestSuiteVersion=2.11.0-SNAPSHOT -PweaveSuiteVersion=2.11.0-SNAPSHOT build
+          ./gradlew --stacktrace --no-problems-report -PskipNodeTests=true build
         shell: bash
 
       # Generate distro
       - name: Create Distro
-        run: ./gradlew --stacktrace --no-problems-report -PweaveVersion=2.11.0-SNAPSHOT -PweaveTestSuiteVersion=2.11.0-SNAPSHOT -PweaveSuiteVersion=2.11.0-SNAPSHOT native-cli:distro
+        run: ./gradlew --stacktrace --no-problems-report native-cli:distro
         shell: bash
 
       # Install Python build dependencies (setuptools/wheel may be missing on Windows runners)
@@ -52,7 +52,7 @@ jobs:
 
       # Generate native-lib python wheel
       - name: Create Native Lib Python Wheel
-        run: ./gradlew --stacktrace --no-problems-report -PweaveVersion=2.11.0-SNAPSHOT native-lib:buildPythonWheel
+        run: ./gradlew --stacktrace --no-problems-report native-lib:buildPythonWheel
         shell: bash
 
       # Setup Node.js for native-lib Node package
@@ -63,12 +63,12 @@ jobs:
 
       # Stage the native lib and build Node package (npm install, node-gyp, tsc, npm pack)
       - name: Create Native Lib Node Package
-        run: ./gradlew --stacktrace --no-problems-report -PweaveVersion=2.11.0-SNAPSHOT native-lib:buildNodePackage
+        run: ./gradlew --stacktrace --no-problems-report native-lib:buildNodePackage
         shell: bash
 
       # Run Node.js tests
       - name: Run Node.js Tests
-        run: ./gradlew --stacktrace --no-problems-report -PweaveVersion=2.11.0-SNAPSHOT native-lib:nodeTest
+        run: ./gradlew --stacktrace --no-problems-report native-lib:nodeTest
         shell: bash
 
       # Upload the artifact file


### PR DESCRIPTION
 ## Problem
 The scheduled `CI Native CLI` workflow fails on `:native-cli:test` (6 failures) with:
  
    NoSuchMethodError: 'void org.mule.weave.v2.model.types.ArrayType.<init>(org.mule.weave.v2.model.values.Value)'
      
## Root cause
The CI steps pinned `-PweaveVersion` / `-PweaveTestSuiteVersion` / `-PweaveSuiteVersion` to `2.11.0-SNAPSHOT` but never overrode `ioVersion`, which `gradle.properties` sets to `2.12.0-20260408`. So `process-module` (via
  `ioVersion`) resolved at 2.12.0 while `runtime` (which provides `ArrayType`, via `weaveVersion`) resolved at 2.11.0-SNAPSHOT — `NativeProcessModule` loaded against an incompatible runtime.
  
The `2.11.0-SNAPSHOT` pins were stale leftovers from before `gradle.properties` was bumped to the 2.12.0 line (de0207a, 2026-05-06). The build has failed on every scheduled run since.
  
## Fix
Drop the stale version overrides from all `gradlew` steps so every dependency resolves to the unified `gradle.properties` defaults (2.12.0), matching the "Run Build (Latest)" intent.
  
## Verification (local, against real Mule artifacts)
  - Old command → 9 passed / **6 failed**
  - New command → **15/15 passed**
