### PR TITLE
W-23475822 fix(build): declare nativeCompile output directory for up-to-date checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,4 +59,10 @@ subprojects {
     dependencies {
         implementation "org.scala-lang:scala-library:${scalaVersion}"
     }
+
+    // Ensure nativeCompile tasks declare their output directories for proper
+    // Gradle up-to-date checks and cross-project dependency resolution
+    tasks.matching { it.name == 'nativeCompile' }.configureEach { t ->
+        t.outputs.dir("${project.buildDir}/native/nativeCompile")
+    }
 }


### PR DESCRIPTION
Extracted from #119 (feat/new-native-bindings) as an independent build-correctness fix.
  
## Problem
The GraalVM `nativeCompile` task did not declare its output directory, so Gradle could not reliably compute up-to-date status or resolve the native artifacts across projects.
  
## Fix
Declare `outputs.dir("${project.buildDir}/native/nativeCompile")` on every `nativeCompile` task in `subprojects` (root `build.gradle`), so incremental builds and cross-project dependency resolution work correctly.
  
## Notes
- Branches off `master`; ~6 lines, no dependency on the new C/Go/Rust bindings in #119.
- Verified: Gradle configures cleanly with the change.
