### PR TITLE
W-23475825 build(native-lib): strip debug symbols and add libdwlib symlink

### DIFF
--- a/native-lib/build.gradle
+++ b/native-lib/build.gradle
@@ -63,10 +63,60 @@ graalvmNative {
   }
 }
 
+// On Linux/macOS, create libdwlib.so symlink for standard -ldwlib linking
+tasks.named('nativeCompile').configure {
+  doLast {
+    if (!System.getProperty('os.name').toLowerCase().contains('windows')) {
+      def nativeDir = file("${buildDir}/native/nativeCompile")
+      def dwlibFile = fileTree(nativeDir).matching { include 'dwlib.so', 'dwlib.dylib' }.singleFile
+      if (dwlibFile?.exists()) {
+        def ext = dwlibFile.name.endsWith('.dylib') ? '.dylib' : '.so'
+        def symlinkTarget = new File(nativeDir, "lib${dwlibFile.name}")
+        if (!symlinkTarget.exists() || symlinkTarget.canonicalFile != dwlibFile.canonicalFile) {
+          ant.symlink(link: symlinkTarget, resource: dwlibFile.name, overwrite: true)
+        }
+      }
+    }
+  }
+}
+
+// Strip debug symbols from native library to reduce artifact size (only on CI or when skipStripDebug is not set)
+tasks.register('stripNativeLibrary', Exec) {
+  dependsOn tasks.named('nativeCompile')
+
+  onlyIf {
+    // Skip stripping if explicitly disabled (for local development with debugging)
+    project.findProperty('skipStripDebug')?.toString()?.toBoolean() != true
+  }
+
+  def nativeDir = file("${buildDir}/native/nativeCompile")
+
+  if (System.getProperty('os.name').toLowerCase().contains('windows')) {
+    // Windows: Use strip from mingw-w64 or MSYS2 if available
+    workingDir(nativeDir)
+    commandLine('cmd', '/c', 'where strip >nul 2>&1 && strip --strip-debug dwlib.dll || echo Strip not available on Windows, skipping')
+    ignoreExitValue = true  // Don't fail if strip is not available on Windows
+  } else if (System.getProperty('os.name').toLowerCase().contains('mac')) {
+    // macOS: Use strip -S to remove debug symbols
+    workingDir(nativeDir)
+    commandLine('strip', '-S', 'dwlib.dylib')
+  } else {
+    // Linux: Use strip --strip-debug
+    workingDir(nativeDir)
+    commandLine('strip', '--strip-debug', 'dwlib.so')
+  }
+
+  doLast {
+    if (executionResult.get().exitValue == 0) {
+      println("✓ Stripped debug symbols from native library")
+    }
+  }
+}
+
 def pythonExe = (project.findProperty('pythonExe') ?: 'python3') as String
 
 tasks.register('stagePythonNativeLib', Copy) {
-  dependsOn tasks.named('nativeCompile')
+  dependsOn tasks.named('stripNativeLibrary')
   from("${buildDir}/native/nativeCompile") {
     include('dwlib.*')
   }
@@ -107,7 +157,7 @@ tasks.register('pythonTest', Exec) {
 // --- Node.js native package tasks ---
 
 tasks.register('stageNodeNativeLib', Copy) {
-  dependsOn tasks.named('nativeCompile')
+  dependsOn tasks.named('stripNativeLibrary')
   from("${buildDir}/native/nativeCompile") {
     include('dwlib.*')
   }


### PR DESCRIPTION
Extracted from #119 (feat/new-native-bindings) as an independent build improvement to the shared native library (`dwlib`) consumed by the **existing** Python and Node bindings.
  
## Changes (`native-lib/build.gradle`)
- **`stripNativeLibrary`:** strip debug symbols from `dwlib` after `nativeCompile` to reduce artifact size (`strip -S` on macOS, `--strip-debug` on Linux, best-effort on Windows). Skippable with `-PskipStripDebug=true` for
  local debugging.
- **`libdwlib` symlink:** on Linux/macOS, create a `libdwlib.{so,dylib}` symlink so consumers can link with the standard `-ldwlib` flag.
- `stagePythonNativeLib` and `stageNodeNativeLib` now depend on `stripNativeLibrary`, so both existing bindings package the stripped library.
  
## Notes
- Branches off `master`; contains **only** the strip + symlink changes — none of the new Go/Rust/C test or packaging tasks from #119.
- Verified with a real GraalVM native build: `nativeCompile → stripNativeLibrary` ("✓ Stripped debug symbols") `→ stagePythonNativeLib` succeeds; `libdwlib.dylib` symlink created; stripped lib staged.

  ---
  Compare links to open them:
  - https://github.com/mulesoft/data-weave-cli/compare/master...fix/gradle-nativecompile-outputs?expand=1
  - https://github.com/mulesoft/data-weave-cli/compare/master...fix/native-lib-strip-and-symlink?expand=1