### PR TITLE
W-23480663 ci: skip regression tests on PRs, run them only on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,12 +45,14 @@ jobs:
         run: |
           ./gradlew --stacktrace --no-problems-report -PskipNodeTests=true build
         shell: bash
-      #Run regression tests
+      # Run regression tests (only on master branch to save CI time on PRs)
       - name: Run regression test 2.9.8
+        if: github.ref == 'refs/heads/master'
         run: |
           ./gradlew --stacktrace -PweaveTestSuiteVersion=2.9.8 -DweaveSuiteVersion=2.9.8 native-cli-integration-tests:test
         shell: bash
       - name: Run regression test 2.10
+        if: github.ref == 'refs/heads/master'
         run: |
           ./gradlew --stacktrace -PweaveTestSuiteVersion=2.10.0 -DweaveSuiteVersion=2.10.0 native-cli-integration-tests:test
         shell: bash


### PR DESCRIPTION
Extracted from #119 as an independent CI cost improvement.
  
## Change
The 2.9.8 and 2.10 regression suites (`native-cli-integration-tests`) run on every push and pull_request, adding significant time to PR builds. Gate both steps behind `github.ref == 'refs/heads/master'` so they run on master pushes but are skipped on PRs — the main build + unit tests still run on PRs.
  
## Notes
- Branches off `master`; +3/−1 lines to `.github/workflows/main.yml`, valid YAML.
- Contains **none** of #119's new-binding CI plumbing (Setup Go/Rust/CMake, packageGo/Rust/C, bindings bundle) — those depend on tasks/dirs that don't exist on master.
