### PR TITLE
W-23517830: Add isolated-process test for bad-library-path initialization in the DataWeave Node.js binding

### DIFF
--- a/native-lib/node/tests/integration/edge-cases.test.ts
+++ b/native-lib/node/tests/integration/edge-cases.test.ts
@@ -108,9 +108,8 @@ describe("multi-instance lifecycle", () => {
   // runtime is loaded process-globally (ref-counted, see g_ref_count in
   // addon.c), so once any good init has run, a later bad-path init is tolerated
   // rather than re-dlopen'd. Because this shared suite loads dwlib in earlier
-  // tests, that path can't be asserted here without a dedicated isolated process
-  // (a follow-up: run it via a separate vitest pool/child so no prior init has
-  // happened). Verified manually: in a fresh process it throws DataWeaveError.
+  // tests, that path can't be asserted here; it is covered in a dedicated child
+  // process in init-bad-path.test.ts.
 });
 
 describe("concurrent execution", () => {

--- a/native-lib/node/tests/integration/fixtures/bad-lib-init.cjs
+++ b/native-lib/node/tests/integration/fixtures/bad-lib-init.cjs
@@ -1,0 +1,33 @@
+// Child-process fixture for the bad-library-path initialization test.
+//
+// Runs in a FRESH process (spawned by init-bad-path.test.ts) so that no prior
+// good initialization has loaded dwlib — the only condition under which a
+// bad-path initialize() reliably throws (the native runtime is loaded
+// process-globally / ref-counted; see the NOTE in edge-cases.test.ts).
+//
+// Contract with the parent:
+//   - Requires the built CommonJS entry at ../../../dist/index.js.
+//   - On the expected DataWeaveError, prints "OK:<name>" and exits 0.
+//   - On any other outcome (no throw, wrong error type), prints "FAIL:..." and
+//     exits 1. A native crash would surface as a non-zero signal exit, which
+//     the parent also treats as failure.
+const path = require("node:path");
+
+const { DataWeave, DataWeaveError } = require(path.join(__dirname, "..", "..", "..", "dist", "index.js"));
+
+const BAD_PATH = process.argv[2] || "/no/such/dwlib-does-not-exist.dylib";
+
+try {
+  const dw = new DataWeave(BAD_PATH);
+  dw.initialize();
+  // Should be unreachable: a bad path in a fresh process must not initialize.
+  console.log("FAIL:no-throw");
+  process.exit(1);
+} catch (e) {
+  if (e instanceof DataWeaveError) {
+    console.log("OK:" + e.name + ":" + String(e.message));
+    process.exit(0);
+  }
+  console.log("FAIL:wrong-error:" + (e && e.constructor && e.constructor.name));
+  process.exit(1);
+}

--- a/native-lib/node/tests/integration/init-bad-path.test.ts
+++ b/native-lib/node/tests/integration/init-bad-path.test.ts
@@ -1,0 +1,31 @@
+// Asserts that DataWeave.initialize() with a bad/nonexistent dwlib path throws
+// a DataWeaveError. This is only reliably observable as the FIRST native
+// initialization in a process (the runtime is loaded process-globally and
+// ref-counted — see the NOTE in edge-cases.test.ts), so it is verified in a
+// dedicated child process rather than in-lane, making it order- and
+// pool-configuration-independent. (W-23517830, follow-up from W-23517404.)
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+const FIXTURE = join(__dirname, "fixtures", "bad-lib-init.cjs");
+const DIST_ENTRY = join(__dirname, "..", "..", "dist", "index.js");
+
+describe("bad library path initialization (isolated process)", () => {
+  it("initialize() with a nonexistent library path throws a DataWeaveError", () => {
+    // The fixture requires the built dist/ entry; nodeTest runs tsc first, but
+    // guard so a source-only run fails with a clear message instead of a
+    // confusing child error.
+    expect(existsSync(DIST_ENTRY), `built entry missing at ${DIST_ENTRY} — run \`npm run build:ts\``).toBe(true);
+
+    // execFileSync throws on a non-zero exit, so a "no throw" / wrong-error /
+    // native-crash outcome in the child fails this test.
+    const stdout = execFileSync(process.execPath, [FIXTURE, "/no/such/dwlib-xyz.dylib"], {
+      encoding: "utf-8",
+    });
+
+    expect(stdout).toContain("OK:DataWeaveError");
+    expect(stdout).toContain("Failed to");
+  });
+});


### PR DESCRIPTION
## What
   
A bad/nonexistent `dwlib` path makes `initialize()` throw a `DataWeaveError` **only as the first native init in a process** — the runtime is loaded process-globally / ref-counted, so once any good init has run, a later bad-path init is tolerated. That made it order-dependent (flaky) in the shared lane.
  
## Approach
  
Run it in a **dedicated child process**, making it order- and vitest-pool-independent:
  
- `tests/integration/fixtures/bad-lib-init.cjs` — child fixture that requires the built `dist/` entry, asserts the `DataWeaveError`, and signals via stdout sentinel + exit code (no-throw / wrong-error / native crash all surface as a non-zero child exit).
- `tests/integration/init-bad-path.test.ts` — spawns the fixture with `execFileSync` (throws on non-zero exit) and asserts the `OK:DataWeaveError` sentinel; guards on the built entry existing.
- `edge-cases.test.ts` — NOTE updated to point at the new test.
  
> Note: vitest's default `forks` pool already isolates per file, so a plain test file would pass today — but relying on that would reintroduce the exact hidden process-global coupling this test guards against. The spawned child is robust to pool/config changes.

## Testing

- `tsc --noEmit` clean
- `npm run test:unit` → **70 passed**
- `npm run test:integration` → **35 passed**, deterministic across repeated runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
