### PR TITLE
W-23530974: Skip slow big_intersection TCK case

### DIFF
--- a/native-lib/node/tests/tck/ignore-list.ts
+++ b/native-lib/node/tests/tck/ignore-list.ts
@@ -95,6 +95,11 @@ export const IGNORED_CASES: Readonly<Record<string, IgnoreEntry>> = {
   "multipart-write-message": { reason: "multipart: empty parts / structural" },
   "multipart-write-subtype-override": { reason: "multipart: subtype override" },
 
+  // slow — pathological type-checking stress case; passes but is far too slow
+  // (~13s locally, ~34s on the Windows CI runner, exceeding the tck 30s
+  // testTimeout). The CLI ignores it for the same "takes too long" reason.
+  "big_intersection": { reason: "slow: 500-way intersection type exceeds the test timeout" },
+
   // nondeterministic — output embeds a timestamp
   "properties-writer": { reason: "nondeterministic: properties output embeds a timestamp comment" },
   "properties-passthrough": { reason: "nondeterministic: properties output embeds a timestamp comment" },


### PR DESCRIPTION
## What
  
Fixes the remaining Windows-only TCK failure after #136. `big_intersection` (a 500-way intersection type stress case) passes functionally but is pathologically slow — ~13s locally, ~34s on the Windows CI runner, exceeding the tck project's 30s `testTimeout`. It passed on macOS/Linux only because they're fast enough.
  
Add it to the ignore list as a slow case, matching the CLI's `TCKCliTest`, which ignores it under "Take too long time" (alongside `array-concat`, `runtime_run`).
  
## Testing

- `npm run test:tck` → **659 passed, 58 skipped, 0 failures**
- `tsc --noEmit` clean 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
