### PR TITLE
Fix input syntax in CLI help example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Commands:
   repl           Starts the DW repl.
 Example:
 
- dw  run -i payload <fullPathToUser.json> "output application/json --- payload
+ dw  run -i payload=<fullPathToUser.json> "output application/json --- payload
 filter (item) -> item.age > 17"
 
  Documentation reference:

--- a/native-cli/src/main/java/org/mule/weave/cli/DWCLI.java
+++ b/native-cli/src/main/java/org/mule/weave/cli/DWCLI.java
@@ -57,7 +57,7 @@ public class DWCLI {
                     "(____/\\_/\\_/(__)\\_/\\_/(_/\\_)(____)\\_/\\_/ \\__/ (____)",
             footer = "Example:\n" +
                     "\n" +
-                    " dw  run -i payload <fullPathToUser.json> \"output application/json --- payload\n" +
+                    " dw  run -i payload=<fullPathToUser.json> \"output application/json --- payload\n" +
                     "filter (item) -> item.age > 17\"\n" +
                     "\n" +
                     " Documentation reference:\n" +

--- a/native-cli/src/test/scala/org/mule/weave/dwnative/cli/DataWeaveCLITest.scala
+++ b/native-cli/src/test/scala/org/mule/weave/dwnative/cli/DataWeaveCLITest.scala
@@ -219,6 +219,18 @@ class DataWeaveCLITest extends AnyFreeSpec with Matchers {
     maybeError.isEmpty shouldBe false
   }
 
+  "should run with input file using name=path form" in {
+    val tmpFile = java.io.File.createTempFile("test-input", ".json")
+    tmpFile.deleteOnExit()
+    java.nio.file.Files.writeString(tmpFile.toPath, """{"greeting":"hello"}""")
+    val stream = new ByteArrayOutputStream()
+    val console = new TestConsole(System.in, stream)
+    val dwcli = createCommandLine(console)
+    val exitCode = dwcli.execute("run", "-i", s"payload=${tmpFile.getAbsolutePath}", "output application/json --- payload.greeting")
+    exitCode shouldBe 0
+    Source.fromBytes(stream.toByteArray, "UTF-8").mkString.trim shouldBe "\"hello\""
+  }
+
   "should run using parameter" in {
     val stream = new ByteArrayOutputStream()
     val testConsole = new TestConsole(System.in, stream)


### PR DESCRIPTION
## What Problem This Solves

The input example shown by `dw --help` and reproduced in the README uses a space between the input name and path. Picocli parses the `-i` option as a map, so its required syntax is `name=path`; copying the existing example results in a command that does not run.

## Why This Change Was Made

- Correct the help footer to use `-i payload=<fullPathToUser.json>`.
- Keep the README's captured help output consistent with the CLI.
- Add a focused test that executes the CLI with the documented `name=path` input form.

## User Impact

Users can copy the input-file example from `dw --help` or the README and run it successfully.

## Evidence

- `./gradlew native-cli:test`
- 16 tests passed with zero failures (15 `DataWeaveCLITest` tests and 1 `DependencyManagerTest`)
- `git diff --check`

Fixes mulesoft/data-weave-cli#113
