### PR TITLE
W-23599683: Stop double-zipping single-file upload artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,28 +73,49 @@ jobs:
 
       # Upload the artifact file
       - name: Upload generated script
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: dw-${{env.NATIVE_VERSION}}-${{runner.os}}
+          # archive:false skips the redundant outer zip (the distro is already a
+          # .zip) and names the artifact after the file — which already carries
+          # ${matrix.script_name}, so the matrix legs don't collide. No `name:`:
+          # it would be ignored under archive:false.
           path: native-cli/build/distributions/native-cli-${{env.NATIVE_VERSION}}-native-distro-${{ matrix.script_name }}.zip
+          archive: false
 
       # Upload the Python wheel
       - name: Upload Python wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: dw-python-wheel-${{env.NATIVE_VERSION}}-${{runner.os}}
+          # archive:false skips the redundant outer zip and names the artifact
+          # after the wheel — whose platform tag (manylinux/win_amd64/…) is
+          # already OS-unique, so the matrix legs don't collide. No `name:`: it
+          # would be ignored under archive:false.
           path: native-lib/python/dist/dataweave_native-0.0.1-py3-*.whl
+          archive: false
+
+      # npm pack emits the same filename (dataweave-native-0.0.1.tgz) on every
+      # OS. With archive:false the file NAME becomes the artifact name (the
+      # `name:` input is ignored), so copy to an OS-qualified name first to keep
+      # the matrix legs from colliding.
+      - name: Stage OS-qualified Node package
+        run: cp native-lib/node/dataweave-native-0.0.1.tgz "native-lib/node/dataweave-native-0.0.1-${{ runner.os }}.tgz"
+        shell: bash
 
       # Upload the Node.js package
       - name: Upload Node package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: dw-node-package-${{env.NATIVE_VERSION}}-${{runner.os}}
-          path: native-lib/node/dataweave-native-0.0.1.tgz
+          path: native-lib/node/dataweave-native-0.0.1-${{ runner.os }}.tgz
+          # Single .tgz (already gzip-compressed); skip the redundant outer zip
+          # (v7+ feature). archive:false ignores `name:` and uses the file name,
+          # which the copy above made OS-unique.
+          archive: false
 
-      # Upload the native shared library + header together per OS
+      # Upload the native shared library + header together per OS. Multiple
+      # files, so this stays archived (archive:false allows only one file); the
+      # zip is wanted here and `name:` still applies.
       - name: Upload native shared library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: dwlib-${{env.NATIVE_VERSION}}-${{runner.os}}
           path: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,28 +110,49 @@ jobs:
 
       # Upload the artifact file
       - name: Upload generated script
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: dw-${{env.NATIVE_VERSION}}-${{runner.os}}
+          # archive:false skips the redundant outer zip (the distro is already a
+          # .zip) and names the artifact after the file — which already carries
+          # ${matrix.script_name}, so the matrix legs don't collide. No `name:`:
+          # it would be ignored under archive:false.
           path: native-cli/build/distributions/native-cli-${{env.NATIVE_VERSION}}-native-distro-${{ matrix.script_name }}.zip
+          archive: false
 
       # Upload the Python wheel
       - name: Upload Python wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: dw-python-wheel-${{env.NATIVE_VERSION}}-${{runner.os}}
+          # archive:false skips the redundant outer zip and names the artifact
+          # after the wheel — whose platform tag (manylinux/win_amd64/…) is
+          # already OS-unique, so the matrix legs don't collide. No `name:`: it
+          # would be ignored under archive:false.
           path: native-lib/python/dist/dataweave_native-0.0.1-py3-*.whl
+          archive: false
+
+      # npm pack emits the same filename (dataweave-native-0.0.1.tgz) on every
+      # OS. With archive:false the file NAME becomes the artifact name (the
+      # `name:` input is ignored), so copy to an OS-qualified name first to keep
+      # the matrix legs from colliding.
+      - name: Stage OS-qualified Node package
+        run: cp native-lib/node/dataweave-native-0.0.1.tgz "native-lib/node/dataweave-native-0.0.1-${{ runner.os }}.tgz"
+        shell: bash
 
       # Upload the Node.js package
       - name: Upload Node package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
-          name: dw-node-package-${{env.NATIVE_VERSION}}-${{runner.os}}
-          path: native-lib/node/dataweave-native-0.0.1.tgz
+          path: native-lib/node/dataweave-native-0.0.1-${{ runner.os }}.tgz
+          # Single .tgz (already gzip-compressed); skip the redundant outer zip
+          # (v7+ feature). archive:false ignores `name:` and uses the file name,
+          # which the copy above made OS-unique.
+          archive: false
 
-      # Upload the native shared library + header together per OS
+      # Upload the native shared library + header together per OS. Multiple
+      # files, so this stays archived (archive:false allows only one file); the
+      # zip is wanted here and `name:` still applies.
       - name: Upload native shared library
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: dwlib-${{env.NATIVE_VERSION}}-${{runner.os}}
           path: |


### PR DESCRIPTION
## Problem

`actions/upload-artifact` always wraps whatever you give it in a `.zip`. Three of our upload steps hand it a file that's **already** an archive — the CLI distro `.zip`, the Python `.whl`, and the Node `.tgz` — so the downloaded artifact is a `.zip` *containing* that file. A consumer has to unzip once just to reach the real distributable (and the outer zip adds no compression on already-compressed input).

## Fix

`actions/upload-artifact@v7.0.0` added an `archive: false` input that uploads a single file as-is. This PR:

- Bumps **all four** upload steps (`main.yml` + `ci.yml`) from `@v4` → `@v7.0.1`.
- Sets `archive: false` on the three single-file artifacts (CLI distro, Python wheel, Node package).
- Leaves the **dwlib** step archived — it uploads 4 files (`.dylib`/`.so`/`.dll`/`.h`) and `archive: false` permits only one. It's bumped to `@v7.0.1` for version consistency; behavior is unchanged (v7 defaults to `archive: true`).

### Naming caveat handled

Under `archive: false` the `name:` input is **ignored** — the uploaded file's own name becomes the artifact name. That's fine for two of the three because their filenames are already OS-unique:

- **CLI distro** — filename carries `${matrix.script_name}` (`…-linux.zip` / `…-windows.zip`).
- **Python wheel** — filename carries the platform tag (`manylinux2014_*` / `win_amd64`).

But **`npm pack` emits an identical `dataweave-native-0.0.1.tgz` on every OS**, which would collide across the matrix (v4+ artifacts are immutable — the second upload errors). A small staging step copies it to an OS-qualified name (`dataweave-native-0.0.1-${{ runner.os }}.tgz`) before upload.

The now-ignored `name:` inputs on the two safe steps were removed so the config isn't misleading.

## Blast radius

- **Release assets are unaffected.** `release.yml` uses `svenstaro/upload-release-action` (a different mechanism with honored `asset_name:` and no zipping) — not `upload-artifact`.
- **No `download-artifact` consumers** depend on the old `dw-…` artifact names (grepped `.github/`).
- **Only visible change:** artifact labels in the Actions UI now match the uploaded file names (e.g. `native-cli-100.100.100-native-distro-linux.zip` instead of `dw-100.100.100-Linux`).

## Testing

`main.yml` and `ci.yml` validated as well-formed YAML. This is CI-runner-only behavior, so it can't be exercised locally — worth watching the first master run to confirm the new artifact shapes and that no immutability/name error fires.

## Note on the v4→v7 bump

This crosses breaking changes (artifact immutability landed in v4, other changes through v5–v7). Our artifact names are already unique per OS/version, so no known conflict — but flagging it since it's a 3-major jump. Pinned to `@v7.0.1` rather than a floating `@v7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
