### PR TITLE
W-23599683: Exclude *.debug from native-lib package staging

### DIFF
--- a/native-lib/build.gradle
+++ b/native-lib/build.gradle
@@ -119,6 +119,10 @@ tasks.register('stagePythonNativeLib', Copy) {
   dependsOn tasks.named('stripNativeLibrary')
   from("${layout.buildDirectory.get().asFile}/native/nativeCompile") {
     include('dwlib.*')
+    // Exclude GraalVM's separate debug-info file (e.g. dwlib.so.debug on Linux):
+    // it's dev-only crash-symbolication data the runtime never loads, and would
+    // otherwise bloat the distributed wheel. Kept in the build dir for debugging.
+    exclude('*.debug')
   }
   into("${projectDir}/python/src/dataweave/native")
 }
@@ -160,6 +164,10 @@ tasks.register('stageNodeNativeLib', Copy) {
   dependsOn tasks.named('stripNativeLibrary')
   from("${layout.buildDirectory.get().asFile}/native/nativeCompile") {
     include('dwlib.*')
+    // Exclude GraalVM's separate debug-info file (e.g. dwlib.so.debug on Linux):
+    // it's dev-only crash-symbolication data the runtime never loads, and would
+    // otherwise bloat the packed .tgz. Kept in the build dir for debugging.
+    exclude('*.debug')
   }
   into("${projectDir}/node/native")
 }


### PR DESCRIPTION
## Problem

`native-lib` builds the GraalVM native image with `debug = true` (see `graalvmNative` block in `native-lib/build.gradle`). On **Linux**, native-image emits a *separate* DWARF debug-info file — `dwlib.so.debug` — alongside the runtime library `dwlib.so`.

Both staging tasks copy the library into their binding packages with the glob `include('dwlib.*')`:

- `stagePythonNativeLib` → `python/src/dataweave/native/`
- `stageNodeNativeLib` → `node/native/`

`dwlib.*` also matches `dwlib.so.debug`, so the debug file leaks into **both** the distributed Python wheel and the Node `.tgz`. It's dev-only crash-symbolication data the runtime never loads — shipping it just bloats the distributables consumers download.

## Fix

Add `exclude('*.debug')` to both staging `from(...) { }` blocks. Only the runtime library (`dwlib.so`/`.dylib`/`.dll`) and header ship; the `.debug` file stays in `build/native/nativeCompile/` for local debugging.

This is intentionally minimal — `debug = true` is left as-is, so developers keep the debug info in the build dir; we just stop *packaging* it.

## Verification caveat

This is **only reproducible on Linux CI**. macOS `native-image` produces a `.dSYM` bundle (a directory, not a `dwlib.*.debug` file), so the leak never appears in local macOS builds — and `.dSYM` isn't matched by `dwlib.*` anyway. Confidence rests on the glob semantics; the first Linux CI run will confirm the `.debug` file is absent from the wheel and tgz.

## Blast radius

- Staging-only change; no runtime, API, or binding-code impact.
- `stripNativeLibrary` (which runs `strip` on the primary lib) is unaffected — it never touched the separate `.debug` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
