### PR TITLE
W-23708419: Simplify TCK test runner configuration

### DIFF
--- a/.github/actions/build-foundation/action.yml
+++ b/.github/actions/build-foundation/action.yml
@@ -29,5 +29,5 @@ runs:
         github-token: ${{ inputs.github-token }}
 
     - name: Run Build
-      run: ./gradlew --stacktrace --no-problems-report -PskipNodeTests=true build ${{ inputs.native-version != '' && format('-PnativeVersion={0}', inputs.native-version) || '' }}
+      run: ./gradlew --stacktrace --no-problems-report -PskipNodeTests=true -PskipTCKTests=true build ${{ inputs.native-version != '' && format('-PnativeVersion={0}', inputs.native-version) || '' }}
       shell: bash

--- a/.github/actions/cli/action.yml
+++ b/.github/actions/cli/action.yml
@@ -44,14 +44,9 @@ runs:
       run: ./gradlew --stacktrace --no-problems-report native-cli:distro ${{ inputs.native-version != '' && format('-PnativeVersion={0}', inputs.native-version) || '' }}
       shell: bash
 
-    - name: Run regression test 2.12.2-SNAPSHOT
+    - name: Run CLI TCK Conformance
       if: inputs.run-tck == 'true'
-      run: ./gradlew --stacktrace -PweaveTestSuiteVersion=2.12.2-SNAPSHOT -DweaveSuiteVersion=2.12.2-SNAPSHOT native-cli-integration-tests:test
-      shell: bash
-
-    - name: Run regression test 2.13.0-SNAPSHOT
-      if: inputs.run-tck == 'true'
-      run: ./gradlew --stacktrace -PweaveTestSuiteVersion=2.13.0-SNAPSHOT -DweaveSuiteVersion=2.13.0-SNAPSHOT native-cli-integration-tests:test
+      run: ./gradlew --stacktrace native-cli-integration-tests:test
       shell: bash
 
     - name: Stage renamed CLI distro

--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -50,17 +50,10 @@ runs:
       run: ./gradlew --stacktrace --no-problems-report native-lib:nodeTest ${{ inputs.native-version != '' && format('-PnativeVersion={0}', inputs.native-version) || '' }}
       shell: bash
 
-    - name: Run Node.js TCK Conformance 2.12.2-SNAPSHOT
+    - name: Run Node.js TCK Conformance
       if: inputs.run-tck == 'true'
       run: |
-        ./gradlew --stacktrace --no-problems-report -PweaveTestSuiteVersion=2.12.2-SNAPSHOT native-lib:stageTckSuites
-        cd native-lib/node && npm run test:tck
-      shell: bash
-
-    - name: Run Node.js TCK Conformance 2.13.0-SNAPSHOT
-      if: inputs.run-tck == 'true'
-      run: |
-        ./gradlew --stacktrace --no-problems-report -PweaveTestSuiteVersion=2.13.0-SNAPSHOT native-lib:stageTckSuites
+        ./gradlew --stacktrace --no-problems-report native-lib:stageTckSuites
         cd native-lib/node && npm run test:tck
       shell: bash
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,9 @@
-weaveVersion=2.13.0-SNAPSHOT
-weaveTestSuiteVersion=2.13.0-SNAPSHOT
+weaveVersion=2.12.2
+weaveTCKVersion=2.13.0-SNAPSHOT
 nativeVersion=100.100.100
 scalaVersion=2.12.18
 ioVersion=2.12.0-20260408
 graalvmVersion=24.0.2
-weaveSuiteVersion=2.13.0-SNAPSHOT
-#Libaries
 scalaTestVersion=3.2.15
 scalaTestPluginVersion=0.33
 

--- a/native-cli-integration-tests/build.gradle
+++ b/native-cli-integration-tests/build.gradle
@@ -54,3 +54,12 @@ tasks.named('processResources') {
 downloadTestSuites.dependsOn(cleanTestSuites)
 test.dependsOn(downloadTestSuites)
 test.dependsOn(":native-cli:nativeCompile")
+
+// Skip TCKCliTest when -PskipTCKTests=true (matches -PskipNodeTests pattern).
+// CI build-foundation passes this flag on non-master branches so TCK only runs via the explicit
+// "Run CLI TCK Conformance" step (master-only), matching Node TCK behavior. Other IT tests run always.
+test {
+    if (project.hasProperty('skipTCKTests') && project.property('skipTCKTests') == 'true') {
+        exclude '**/TCKCliTest.class'
+    }
+}

--- a/native-cli-integration-tests/build.gradle
+++ b/native-cli-integration-tests/build.gradle
@@ -17,9 +17,9 @@ sourceSets {
 dependencies {
     api(project(":native-cli"))
 
-    weaveSuite "org.mule.weave:runtime:${weaveTestSuiteVersion}:tck@zip"
-    weaveSuite "org.mule.weave:yaml-module:${weaveTestSuiteVersion}:tck@zip"
-    weaveSuite "org.mule.weave:core-modules:${weaveTestSuiteVersion}:tck@zip"
+    weaveSuite "org.mule.weave:runtime:${weaveTCKVersion}:tck@zip"
+    weaveSuite "org.mule.weave:yaml-module:${weaveTCKVersion}:tck@zip"
+    weaveSuite "org.mule.weave:core-modules:${weaveTCKVersion}:tck@zip"
     testRuntimeOnly 'com.vladsch.flexmark:flexmark-all:0.64.8'
     // https://mvnrepository.com/artifact/org.scalatest/scalatest
     testImplementation group: 'org.scalatest', name: 'scalatest_2.12', version: '3.2.19'
@@ -54,9 +54,3 @@ tasks.named('processResources') {
 downloadTestSuites.dependsOn(cleanTestSuites)
 test.dependsOn(downloadTestSuites)
 test.dependsOn(":native-cli:nativeCompile")
-
-test {
-    if (System.getProperty("weaveSuiteVersion") != null) {
-        systemProperty "weaveSuiteVersion", System.getProperty("weaveSuiteVersion")
-    }
-}

--- a/native-cli-integration-tests/src/test/scala/org/mule/weave/clinative/TCKCliTest.scala
+++ b/native-cli-integration-tests/src/test/scala/org/mule/weave/clinative/TCKCliTest.scala
@@ -29,15 +29,15 @@ class TCKCliTest extends AnyFunSpec with Matchers
   private val INPUT_FILE_PATTERN = Pattern.compile("in[0-9]+\\.[a-zA-Z]+")
   private val OUTPUT_FILE_PATTERN = Pattern.compile("out\\.[a-zA-Z]+")
 
-
-  private val weaveVersion = System.getProperty("weaveSuiteVersion", ComponentVersion.weaveVersion)
+  private val weaveVersion = ComponentVersion.weaveVersion
   println(s"****** Running with weaveSuiteVersion: $weaveVersion *******")
   private val versionString: String = DataWeaveVersion(weaveVersion).toString()
+  private val weaveTCKVersion = System.getProperty("weaveSuiteVersion", ComponentVersion.weaveTCKVersion)
 
   private val testSuites = Seq(
-    TestSuite("runtime-tck-tests", loadTestZipFile(s"weave-suites/runtime-$weaveVersion-tck.zip")),
-    TestSuite("yaml-tck-tests", loadTestZipFile(s"weave-suites/yaml-module-$weaveVersion-tck.zip")),
-    TestSuite("core-modules-tck-tests", loadTestZipFile(s"weave-suites/core-modules-$weaveVersion-tck.zip"))
+    TestSuite("runtime-tck-tests", loadTestZipFile(s"weave-suites/runtime-$weaveTCKVersion-tck.zip")),
+    TestSuite("yaml-tck-tests", loadTestZipFile(s"weave-suites/yaml-module-$weaveTCKVersion-tck.zip")),
+    TestSuite("core-modules-tck-tests", loadTestZipFile(s"weave-suites/core-modules-$weaveTCKVersion-tck.zip"))
   )
 
   private def loadTestZipFile(testSuiteExample: String): File = {
@@ -48,8 +48,8 @@ class TCKCliTest extends AnyFunSpec with Matchers
     zipFile
   }
 
-
   println("NativeCliRuntimeTest -> " + testSuites.mkString(","))
+
   testSuites.foreach {
     testSuite => {
       val wd = Files.createTempDirectory(testSuite.name).toFile

--- a/native-cli/build.gradle
+++ b/native-cli/build.gradle
@@ -65,6 +65,7 @@ task genVersions() {
     outputPrinter.println("object ComponentVersion {")
     outputPrinter.println("\tval weaveVersion = \"" + weaveVersion + "\"")
     outputPrinter.println("\tval nativeVersion = \"" + nativeVersion + "\"")
+    outputPrinter.println("\tval weaveTCKVersion = \"" + weaveTCKVersion + "\"")
     outputPrinter.println("}")
     outputPrinter.close()
 }

--- a/native-lib/build.gradle
+++ b/native-lib/build.gradle
@@ -182,8 +182,8 @@ configurations {
 }
 
 dependencies {
-  weaveTckSuite "org.mule.weave:runtime:${weaveTestSuiteVersion}:tck@zip"
-  weaveTckSuite "org.mule.weave:core-modules:${weaveTestSuiteVersion}:tck@zip"
+  weaveTckSuite "org.mule.weave:runtime:${weaveTCKVersion}:tck@zip"
+  weaveTckSuite "org.mule.weave:core-modules:${weaveTCKVersion}:tck@zip"
 }
 
 def tckSuitesDir = "${projectDir}/node/tests/tck/suites"


### PR DESCRIPTION
## Summary
Simplifies TCK test runner configuration and aligns CLI/Node TCK execution behavior.

## Problems
1. **Dual-version TCK loop**: CI ran **two separate TCK steps** per artifact (one for `2.12.2-SNAPSHOT`, one for `2.13.0-SNAPSHOT`), doubling TCK CI time with version overrides hidden in workflow YAML.
2. **CLI/Node TCK asymmetry**: CLI TCK ran on every PR via `build-foundation`, while Node TCK only ran on master. This made PR CI slower without proportional value.

## Solution

### 1. Single TCK version in gradle.properties
Split `weaveVersion` (runtime) from `weaveTCKVersion` (test suite):
```properties
weaveVersion=2.12.2-SNAPSHOT          # runtime at latest stable release
weaveTCKVersion=2.13.0-SNAPSHOT       # TCK at latest for forward compatibility
```

**Changes:**
- **gradle.properties** — replaced `weaveTestSuiteVersion` + `weaveSuiteVersion` with single `weaveTCKVersion`
- **native-cli/build.gradle** — `genVersions` exposes `ComponentVersion.weaveTCKVersion`
- **TCKCliTest.scala** — loads test suites using `weaveTCKVersion`
- **native-lib/build.gradle** — uses `weaveTCKVersion` for staging TCK suites
- **CI actions (cli/node)** — removed dual-version TCK steps → single step per artifact

### 2. Master-only TCK execution (CLI + Node)
Make CLI TCK behavior consistent with Node: both now run only on master.

**Changes:**
- **build-foundation/action.yml** — added `-PskipTCKTests=true` flag (matches existing `-PskipNodeTests` pattern)
- **native-cli-integration-tests/build.gradle** — added test exclusion filter to skip `TCKCliTest` when flag is set
- Other integration tests (`NativeCliTest`) still run on every PR
- CLI TCK still runs explicitly on master via "Run CLI TCK Conformance" step

## Benefits
- **Halves TCK CI time** (one run per artifact instead of two)
- **Faster PR builds** (TCK runs only on master, not every PR)
- **Centralizes version control** in `gradle.properties` (not workflow YAML)
- **Clarifies intent** — runtime version vs. test-suite version are explicit
- **Consistent TCK behavior** — CLI and Node both master-only

## Testing
- [x] Property validation confirms `-PskipTCKTests=true` excludes `TCKCliTest`
- [x] Property validation confirms TCKCliTest runs when flag is absent
- [ ] CI runs green with simplified workflow

## Test plan
Verify CI passes on this PR with the simplified workflow and master-only TCK execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)