### PR TITLE
W-23708419: Actually exclude TCK conformance on PR builds via scalatest tag

### DIFF
--- a/native-cli-integration-tests/build.gradle
+++ b/native-cli-integration-tests/build.gradle
@@ -55,11 +55,16 @@ downloadTestSuites.dependsOn(cleanTestSuites)
 test.dependsOn(downloadTestSuites)
 test.dependsOn(":native-cli:nativeCompile")
 
-// Skip TCKCliTest when -PskipTCKTests=true (matches -PskipNodeTests pattern).
-// CI build-foundation passes this flag on non-master branches so TCK only runs via the explicit
-// "Run CLI TCK Conformance" step (master-only), matching Node TCK behavior. Other IT tests run always.
+// TCK conformance is master-only. On non-master CI, build-foundation passes
+// -PskipTCKTests=true; we exclude the TckConformance-tagged scenarios so they
+// don't run, while the module's other IT specs still do. This uses ScalaTest
+// tag exclusion (maiflai's `tags { exclude }` -> scalatest `-l <tag>`) rather
+// than Gradle's Test.exclude class-pattern filter, which is a no-op under the
+// maiflai scalatest runner. Mirrors the master-only Node TCK lane.
 test {
     if (project.hasProperty('skipTCKTests') && project.property('skipTCKTests') == 'true') {
-        exclude '**/TCKCliTest.class'
+        tags {
+            exclude 'org.mule.weave.clinative.TckConformance'
+        }
     }
 }

--- a/native-cli-integration-tests/src/test/scala/org/mule/weave/clinative/TCKCliTest.scala
+++ b/native-cli-integration-tests/src/test/scala/org/mule/weave/clinative/TCKCliTest.scala
@@ -5,6 +5,7 @@ import org.apache.commons.io.FilenameUtils
 import org.mule.weave.v2.helper.FolderBasedTest
 import org.mule.weave.v2.utils.DataWeaveVersion
 import org.mule.weave.v2.version.ComponentVersion
+import org.scalatest.Tag
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -17,6 +18,10 @@ import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 import java.util.zip.ZipFile
 import scala.collection.JavaConverters._
+
+// TCK conformance scenarios are tagged so CI can exclude them on non-master
+// (PR) builds via -PskipTCKTests=true, matching the master-only Node TCK lane.
+object TckConformance extends Tag("org.mule.weave.clinative.TckConformance")
 
 class TCKCliTest extends AnyFunSpec with Matchers
   with FolderBasedTest
@@ -142,7 +147,7 @@ class TCKCliTest extends AnyFunSpec with Matchers
     val scenarios = unsortedScenarios.sortBy(_.name)
     scenarios.foreach {
       scenario =>
-        it(scenario.name) {
+        it(scenario.name, TckConformance) {
           var args = Array("run")
 
           // Add inputs


### PR DESCRIPTION
## Problem

The project convention is that the DataWeave TCK conformance suite runs **only on master**, not on PRs (see `CLAUDE.md` → CI). CI enforces this two ways:

- The dedicated `Run CLI TCK Conformance` step is gated on `github.ref == 'refs/heads/master'` ✅ (correctly skipped on PRs).
- The earlier `build-foundation` step runs on every branch and passes `-PskipTCKTests=true`, which was supposed to exclude the TCK suite from the aggregate `build`.

But `-PskipTCKTests=true` used Gradle's `Test.exclude('**/TCKCliTest.class')`, and **that filter is a no-op under the `com.github.maiflai.scalatest` runner** — the plugin replaces Gradle's test runner and ignores its include/exclude class-pattern filters. So all **708 TCK scenarios still ran on every PR** inside `build-foundation` (~3–4 min per OS × 3 OSes), silently defeating the master-only intent.

## Fix

Use ScalaTest tag exclusion, which the maiflai runner *does* honor:

- Tag the TCK scenarios with a ScalaTest `Tag` (`TckConformance`).
- When `-PskipTCKTests=true`, exclude that tag via the plugin's `tags { exclude }` DSL (maps to scalatest's `-l <tag>` runner arg — verified against the plugin source in `gradle-scalatest` 0.33).

On PR builds the tagged scenarios are now filtered out while the module's other IT specs still run. The master-only `Run CLI TCK Conformance` step is unaffected.

## Verification

`./gradlew native-cli-integration-tests:test -PskipTCKTests=true` locally:

- **Before:** 708 TCK scenarios executed.
- **After:** `Total number of tests run: 5` (the non-TCK IT specs), TCK scenarios excluded, `BUILD SUCCESSFUL`.

### Note

The `****** Running with weaveSuiteVersion ******` log line and TCK zip extraction still appear, because they run in the `TCKCliTest` class constructor when the class is instantiated. Tag exclusion filters the test *bodies* (the expensive native `dw run` invocations), not class construction — so the conformance work no longer runs, but the constructor-level logging remains. Eliminating that entirely would require gating the whole `test` task (a larger behavioral change that also drops the other IT specs from PR builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)